### PR TITLE
replace 'default' by 'value' in params

### DIFF
--- a/src/pymodaq_plugins_newport/daq_move_plugins/daq_move_Newport_XPS_Q8.py
+++ b/src/pymodaq_plugins_newport/daq_move_plugins/daq_move_Newport_XPS_Q8.py
@@ -172,10 +172,10 @@ class DAQ_Move_Newport_XPS_Q8(DAQ_Move_base):
     data_actuator_type = DataActuatorType['DataActuator']  
 
 
-    params = [{'title':'XPS IP address :', 'name':'xps_ip_address', 'type' : 'str', 'default' : '192.168.0.254'}, #IP address of my system
-              {'title':'XPS Port :', 'name':'xps_port', 'type' : 'int', 'default' : 5001}, #Port of my system, should be the same for others ?
-              {'title':'Group :', 'name':'group', 'type' : 'str', 'default' : 'Group2'},    #Group to be moved
-              {'title':'Positionner :', 'name':'positionner', 'type' : 'str', 'default' : 'Pos'}    #positionner to be moved
+    params = [{'title':'XPS IP address :', 'name':'xps_ip_address', 'type' : 'str', 'value' : '192.168.0.254'}, #IP address of my system
+              {'title':'XPS Port :', 'name':'xps_port', 'type' : 'int', 'value' : 5001}, #Port of my system, should be the same for others ?
+              {'title':'Group :', 'name':'group', 'type' : 'str', 'value' : 'Group2'},    #Group to be moved
+              {'title':'Positionner :', 'name':'positionner', 'type' : 'str', 'value' : 'Pos'}    #positionner to be moved
                 ] + comon_parameters_fun(is_multiaxes, axis_names=_axis_names, epsilon=_epsilon)
 
     def ini_attributes(self):


### PR DESCRIPTION
Hi, thanks for the nice working plugin!

I just replaced all the 'default' dictionaries keys by 'value' in the param dictionnary like so :
`{'title':'XPS IP address :', 'name':'xps_ip_address', 'type' : 'str', 'value' : '192.168.254.254'},`

This makes it so that they are actually shown at this value by default, which is quite helpful since it's hard to guess what to put otherwise.